### PR TITLE
[REFACTORING]: Enhance existing TypeScript types and improve clarity

### DIFF
--- a/src/v6y-bfb-frontend-auditor/src/auditors/FrontendStaticStatusAuditorManager.ts
+++ b/src/v6y-bfb-frontend-auditor/src/auditors/FrontendStaticStatusAuditorManager.ts
@@ -23,20 +23,14 @@ const startFrontendStaticAudit = async ({ applicationId, workspaceFolder }: Audi
             ...currentConfig,
             applicationId,
             workspaceFolder,
-        };
+        } as WorkerOptions;
 
-        await forkWorker(
-            './src/workers/CodeQualityAnalysisWorker.ts',
-            workerConfig as WorkerOptions,
-        );
+        await forkWorker('./src/workers/CodeQualityAnalysisWorker.ts', workerConfig);
         AppLogger.info(
             '[FrontendAuditorManager - startFrontendStaticAudit] CodeQuality Audit have completed successfully.',
         );
 
-        await forkWorker(
-            './src/workers/DependenciesAnalysisWorker.ts',
-            workerConfig as WorkerOptions,
-        );
+        await forkWorker('./src/workers/DependenciesAnalysisWorker.ts', workerConfig);
         AppLogger.info(
             '[FrontendAuditorManager - startFrontendStaticAudit] Dependencies Audit have completed successfully.',
         );

--- a/src/v6y-bfb-frontend-auditor/src/auditors/code-modularity/CodeModularityUtils.ts
+++ b/src/v6y-bfb-frontend-auditor/src/auditors/code-modularity/CodeModularityUtils.ts
@@ -110,8 +110,8 @@ const normalizeProjectTree = (tree: ProjectTree): NormalizedProjectTree => {
         };
     }
 
-    return Object.keys(tree).reduce(
-        (acc: NormalizedProjectTree, node: string): NormalizedProjectTree => {
+    return Object.keys(tree).reduce<NormalizedProjectTree>(
+        (acc, node) => {
             return {
                 ...acc,
                 nodes: [...acc.nodes, node],
@@ -197,14 +197,14 @@ const formatCodeModularityReports = ({
 
         if (Object.keys(interactionCommunities ?? {})?.length) {
             const interactionCommunitiesGroups = Object.keys(interactionCommunities ?? {}).reduce(
-                (acc: { [key: string]: string[] }, next: string) => {
+                (acc, next) => {
                     const groupName = `group-${interactionCommunities?.[next]}`; // Optional chaining for safety
                     return {
                         ...acc,
                         [groupName]: [...(acc[groupName] || []), next],
                     };
                 },
-                {} as { [key: string]: string[] },
+                {} as Record<string, string[]>,
             );
 
             for (const interactionCommunitiesGroup of Object.keys(interactionCommunitiesGroups)) {

--- a/src/v6y-bfb-frontend-auditor/src/auditors/code-security/CodeSecurityUtils-test.ts
+++ b/src/v6y-bfb-frontend-auditor/src/auditors/code-security/CodeSecurityUtils-test.ts
@@ -1,12 +1,11 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { AuditUtils, auditStatus } from '@v6y/commons';
-import { describe, expect, it, vi } from 'vitest';
+import { Mock, describe, expect, it, vi } from 'vitest';
 
 import { AuditCommonsType } from '../types/AuditCommonsType.ts';
 import CodeSecurityUtils from './CodeSecurityUtils.ts';
 
 vi.mock('@v6y/commons', async () => {
-    const actualModule = (await vi.importActual('@v6y/commons')) as typeof import('@v6y/commons');
+    const actualModule = await vi.importActual('@v6y/commons');
 
     return {
         ...actualModule,
@@ -25,7 +24,7 @@ describe('CodeSecurityUtils.formatCodeModularityReports', () => {
     });
 
     it('should return an empty array when no files are found', async () => {
-        (AuditUtils.getFiles as any).mockReturnValue({ files: [], basePath: '/base' });
+        (AuditUtils.getFiles as Mock).mockReturnValue({ files: [], basePath: '/base' });
 
         const result = await CodeSecurityUtils.formatCodeModularityReports({
             application: {},
@@ -36,16 +35,16 @@ describe('CodeSecurityUtils.formatCodeModularityReports', () => {
     });
 
     it('should generate security audit reports when non-compliant files are found', async () => {
-        (AuditUtils.getFiles as any).mockReturnValue({
+        (AuditUtils.getFiles as Mock).mockReturnValue({
             files: ['file1.js', 'file2.ts'],
             basePath: '/base',
         });
 
-        (AuditUtils.parseFile as any)
+        (AuditUtils.parseFile as Mock)
             .mockReturnValueOnce({ source: ['some code', 'eval();'] })
             .mockReturnValueOnce({ source: ['other code'] });
 
-        (AuditUtils.isNonCompliantFile as any)
+        (AuditUtils.isNonCompliantFile as Mock)
             .mockResolvedValueOnce(true) // Non-compliant for the first file
             .mockResolvedValueOnce(false) // Compliant for the second file
             .mockResolvedValueOnce(false) // Compliant for the first file (second anti-pattern)
@@ -77,7 +76,7 @@ describe('CodeSecurityUtils.formatCodeModularityReports', () => {
     });
 
     it('should handle errors gracefully', async () => {
-        (AuditUtils.getFiles as any).mockImplementationOnce(() => {
+        (AuditUtils.getFiles as Mock).mockImplementationOnce(() => {
             throw new Error('Some error');
         });
 


### PR DESCRIPTION
**[REFACTORING]:** Enhance existing TypeScript types and improve clarity

Description
-  It's just a first small PR to suggest some TypeScript type improvement,  ofc,  the review is still in progress and this is the first suggestion ^^

Note:
* The type change in the reduce method for example aims to reduce boilerplate by allowing TypeScript to infer types automatically, rather than specifying them explicitly. 
* I use `Record<string, string[]>`  because I think this syntaxe is much better for readability, this assertion can also be  `{ [key: string]: string[] }
`