### PR TITLE
feature : added DORA metrics audit reports in the frontend

### DIFF
--- a/v6y-apps/bfb-devops-auditor/src/__tests__/DoraMetricsUtils-test.ts
+++ b/v6y-apps/bfb-devops-auditor/src/__tests__/DoraMetricsUtils-test.ts
@@ -91,7 +91,7 @@ describe('DoraMetricsUtils', () => {
                     appId: 1,
                 },
                 score: -1,
-                scoreUnit: 'percentage',
+                scoreUnit: '%',
                 status: auditStatus.error,
             },
             {
@@ -113,7 +113,7 @@ describe('DoraMetricsUtils', () => {
                 category: devOpsCategories.UP_TIME_AVERAGE,
                 status: auditStatus.warning,
                 score: 84.55671296296296,
-                scoreUnit: 'percentage',
+                scoreUnit: '%',
                 module: {
                     appId: 1,
                 },

--- a/v6y-apps/bfb-devops-auditor/src/auditors/dora-metrics/DoraMetricsUtils.ts
+++ b/v6y-apps/bfb-devops-auditor/src/auditors/dora-metrics/DoraMetricsUtils.ts
@@ -473,7 +473,7 @@ const analyseDoraMetrics = ({
             category: devOpsCategories.CHANGE_FAILURE_RATE,
             status: changeFailureRate.status,
             score: changeFailureRate.value,
-            scoreUnit: 'percentage',
+            scoreUnit: '%',
             module: {
                 appId: application?._id,
             },
@@ -499,7 +499,7 @@ const analyseDoraMetrics = ({
             category: devOpsCategories.UP_TIME_AVERAGE,
             status: upTimeAverage.status,
             score: upTimeAverage.value,
-            scoreUnit: 'percentage',
+            scoreUnit: '%',
             module: {
                 appId: application?._id,
             },

--- a/v6y-apps/front/src/commons/config/VitalityCommonConfig.tsx
+++ b/v6y-apps/front/src/commons/config/VitalityCommonConfig.tsx
@@ -91,6 +91,7 @@ export const AUDIT_REPORT_TYPES = {
     codeCoupling: 'Code-Coupling',
     codeSecurity: 'Code-Security',
     codeDuplication: 'Code-Duplication',
+    DORA: 'DORA',
 };
 
 export const buildBreadCrumbItems = ({ currentPage, lastPage, urlParams }: BreadCrumbItemType) => {

--- a/v6y-apps/front/src/features/app-details/components/audit-reports/VitalityAuditReportsTypeGrouper.tsx
+++ b/v6y-apps/front/src/features/app-details/components/audit-reports/VitalityAuditReportsTypeGrouper.tsx
@@ -44,12 +44,10 @@ const VitalityAuditReportsTypeGrouper = ({ auditReports }: { auditReports: Audit
                                 <VitalityCodeStatusReportsBranchGrouper
                                     reports={data as AuditType[]}
                                 />
-                        )}
-                        {(
-                            group === AUDIT_REPORT_TYPES.DORA && data &&
-                        (
+                            )}
+                        {group === AUDIT_REPORT_TYPES.DORA && data && (
                             <VitalityDoraReportsGrouper reports={data as AuditType[]} />
-                        ))}
+                        )}
                     </div>
                 );
             }}

--- a/v6y-apps/front/src/features/app-details/components/audit-reports/VitalityAuditReportsTypeGrouper.tsx
+++ b/v6y-apps/front/src/features/app-details/components/audit-reports/VitalityAuditReportsTypeGrouper.tsx
@@ -13,6 +13,10 @@ const VitalityLighthouseReportsDeviceGrouper = DynamicLoader(
     () => import('./auditors/lighthouse/VitalityLighthouseReportsDeviceGrouper'),
 );
 
+const VitalityDoraReportsGrouper = DynamicLoader(
+    () => import('./auditors/dora/VitalityDoraReportsGrouper'),
+);
+
 const VitalityAuditReportsTypeGrouper = ({ auditReports }: { auditReports: AuditType[] }) => {
     return (
         <VitalityTabGrouperView
@@ -21,14 +25,7 @@ const VitalityAuditReportsTypeGrouper = ({ auditReports }: { auditReports: Audit
             align="center"
             criteria="type"
             hasAllGroup={false}
-            dataSource={[
-                ...(auditReports?.filter(
-                    (report) => report?.type === AUDIT_REPORT_TYPES.lighthouse,
-                ) || []),
-                ...(auditReports?.filter(
-                    (report) => report?.type !== AUDIT_REPORT_TYPES.lighthouse,
-                ) || []),
-            ]}
+            dataSource={auditReports}
             onRenderChildren={(group, data) => {
                 return (
                     <div
@@ -47,7 +44,12 @@ const VitalityAuditReportsTypeGrouper = ({ auditReports }: { auditReports: Audit
                                 <VitalityCodeStatusReportsBranchGrouper
                                     reports={data as AuditType[]}
                                 />
-                            )}
+                        )}
+                        {(
+                            group === AUDIT_REPORT_TYPES.DORA && data &&
+                        (
+                            <VitalityDoraReportsGrouper reports={data as AuditType[]} />
+                        ))}
                     </div>
                 );
             }}

--- a/v6y-apps/front/src/features/app-details/components/audit-reports/auditors/dora/VitalityDoraReportItem.tsx
+++ b/v6y-apps/front/src/features/app-details/components/audit-reports/auditors/dora/VitalityDoraReportItem.tsx
@@ -1,0 +1,78 @@
+import { AuditType } from '@v6y/core-logic/src/types';
+import {
+    Button,
+    Card,
+    Col,
+    InfoCircleOutlined,
+    Row,
+    Statistic,
+    TextView,
+    TitleView,
+    useThemeConfigProvider,
+} from '@v6y/ui-kit';
+import * as React from 'react';
+
+import VitalityTerms from '../../../../../../commons/config/VitalityTerms';
+import { VitalityModuleType } from '../../../../../../commons/types/VitalityModulesProps';
+
+type VitalityDoraReportItemProps = {
+    report: AuditType;
+    onOpenHelpClicked: (helpDetails: VitalityModuleType) => void;
+};
+
+const VitalityDoraReportItem = ({
+    report,
+    onOpenHelpClicked,
+}: VitalityDoraReportItemProps) => {
+    const { currentConfig } = useThemeConfigProvider();
+    const qualityMetricStatus = currentConfig?.status || {};
+    const qualityMetricStatusIcons = currentConfig?.statusIcons || {};
+
+    return (
+        <Card
+            key={`${report.type}-${report.category}`}
+            title={<TitleView level={4} title={report.category as string} />}
+            actions={[
+                <Button
+                    key="help-button"
+                    data-testid="help-button"
+                    icon={<InfoCircleOutlined />}
+                    type="text"
+                    onClick={() => onOpenHelpClicked(report as VitalityModuleType)}
+                />,
+            ]}
+        >
+            <Card.Meta
+                description={
+                    <Row gutter={[16, 16]} justify="center" align="middle">
+                        <Col span={22}>
+                            <TextView
+                                content={`${VitalityTerms.VITALITY_APP_DETAILS_AUDIT_HELP_CATEGORY_LABEL}: ${report.category}`}
+                            />
+                        </Col>
+                        <Col span={22}>
+                            <Statistic
+                                value={report.score || 0}
+                                suffix={report.scoreUnit || ''}
+                                valueStyle={{
+                                    color: qualityMetricStatus[
+                                        (report.status as keyof typeof qualityMetricStatus) ||
+                                            'default'
+                                    ],
+                                }}
+                                prefix={
+                                    qualityMetricStatusIcons[
+                                        (report.status as keyof typeof qualityMetricStatusIcons) ||
+                                            'default'
+                                    ]
+                                }
+                            />
+                        </Col>
+                    </Row>
+                }
+            />
+        </Card>
+    );
+};
+
+export default VitalityDoraReportItem;

--- a/v6y-apps/front/src/features/app-details/components/audit-reports/auditors/dora/VitalityDoraReportItem.tsx
+++ b/v6y-apps/front/src/features/app-details/components/audit-reports/auditors/dora/VitalityDoraReportItem.tsx
@@ -20,10 +20,7 @@ type VitalityDoraReportItemProps = {
     onOpenHelpClicked: (helpDetails: VitalityModuleType) => void;
 };
 
-const VitalityDoraReportItem = ({
-    report,
-    onOpenHelpClicked,
-}: VitalityDoraReportItemProps) => {
+const VitalityDoraReportItem = ({ report, onOpenHelpClicked }: VitalityDoraReportItemProps) => {
     const { currentConfig } = useThemeConfigProvider();
     const qualityMetricStatus = currentConfig?.status || {};
     const qualityMetricStatusIcons = currentConfig?.statusIcons || {};

--- a/v6y-apps/front/src/features/app-details/components/audit-reports/auditors/dora/VitalityDoraReportsGrouper.tsx
+++ b/v6y-apps/front/src/features/app-details/components/audit-reports/auditors/dora/VitalityDoraReportsGrouper.tsx
@@ -1,0 +1,16 @@
+import { AuditType } from '@v6y/core-logic/src/types';
+import { DynamicLoader } from '@v6y/ui-kit';
+import * as React from 'react';
+
+import { VitalityModuleType } from '../../../../../../commons/types/VitalityModulesProps';
+
+const VitalityModuleList = DynamicLoader(
+    () => import('../../../../../../commons/components/modules/VitalityModuleList'),
+);
+
+const VitalityDoraReportsGrouper = ({ reports }: { reports: AuditType[] }) => {
+    return <VitalityModuleList modules={reports as VitalityModuleType[]} source="dora" />;
+};
+
+export default VitalityDoraReportsGrouper;
+

--- a/v6y-apps/front/src/features/app-details/components/audit-reports/auditors/dora/VitalityDoraReportsGrouper.tsx
+++ b/v6y-apps/front/src/features/app-details/components/audit-reports/auditors/dora/VitalityDoraReportsGrouper.tsx
@@ -13,4 +13,3 @@ const VitalityDoraReportsGrouper = ({ reports }: { reports: AuditType[] }) => {
 };
 
 export default VitalityDoraReportsGrouper;
-


### PR DESCRIPTION
## ✨ Title : added DORA metrics audit reports in the frontend

## Commits
- **[FEATURE]**: add DORA reports in frontend
- **[REFACTOR]**: change scoreUnit from 'percentage' to '%' in DoraMetricsUtils
- **[FIX]**: fixed formating errors

## 📄 Description

Adding DORA report type and components:

* `VitalityCommonConfig.tsx`: Added 'DORA' to the `AUDIT_REPORT_TYPES` object.
* `VitalityAuditReportsTypeGrouper.tsx`: Added a dynamic loader for `VitalityDoraReportsGrouper` and updated the `dataSource` and rendering logic to include DORA reports. 
* `VitalityDoraReportItem.tsx`: Implemented a new component to display individual DORA report items.
* `VitalityDoraReportsGrouper.tsx`: Implemented a new component to group DORA reports.

Changes to score unit representation:

* `DoraMetricsUtils-test.ts`: Updated the `scoreUnit` from 'percentage' to '%' in multiple test cases.
* `DoraMetricsUtils.ts`: Updated the `scoreUnit` from 'percentage' to '%' in the `analyseDoraMetrics` function.
