### PR TITLE
[FEATURE]: add DataDog configuration support in application management

### DIFF
--- a/v6y-apps/bff/src/resolvers/application/ApplicationMutations.ts
+++ b/v6y-apps/bff/src/resolvers/application/ApplicationMutations.ts
@@ -25,6 +25,10 @@ const createOrEditApplication = async (
             gitWebUrl,
             productionLink,
             additionalProductionLinks,
+            dataDogApiKey,
+            dataDogAppKey,
+            dataDogUrl,
+            dataDogMonitorId,
             contactMail,
             codeQualityPlatformLink,
             ciPlatformLink,
@@ -40,6 +44,17 @@ const createOrEditApplication = async (
         AppLogger.info(
             `[AppMutations - createOrEditApplication] gitOrganization : ${gitOrganization}`,
         );
+        AppLogger.info(
+            `[AppMutations - createOrEditApplication] dataDogApiKey : ${dataDogApiKey ? '"********"}`,' : 'null'}`,
+        );
+        AppLogger.info(
+            `[AppMutations - createOrEditApplication] dataDogAppKey : ${dataDogAppKey ? '"********"}`,' : 'null'}`,
+        );
+        AppLogger.info(`[AppMutations - createOrEditApplication] dataDogUrl : ${dataDogUrl}`);
+        AppLogger.info(
+            `[AppMutations - createOrEditApplication] dataDogMonitorId : ${dataDogMonitorId}`,
+        );
+
         AppLogger.info(
             `[AppMutations - createOrEditApplication] productionLink : ${productionLink}`,
         );
@@ -65,7 +80,11 @@ const createOrEditApplication = async (
                 ciPlatformLink,
                 deploymentPlatformLink,
                 additionalProductionLinks,
-            });
+                dataDogApiKey,
+                dataDogAppKey,
+                dataDogUrl,
+                dataDogMonitorId,
+            } as ApplicationInputType);
 
             AppLogger.info(
                 `[AppMutations - createOrEditApplication] editedApplication : ${editedApplication?._id}`,
@@ -87,6 +106,10 @@ const createOrEditApplication = async (
             ciPlatformLink,
             deploymentPlatformLink,
             additionalProductionLinks,
+            dataDogApiKey,
+            dataDogAppKey,
+            dataDogUrl,
+            dataDogMonitorId,
         } as ApplicationInputType);
 
         AppLogger.info(

--- a/v6y-apps/bff/src/types/VitalityTypes.ts
+++ b/v6y-apps/bff/src/types/VitalityTypes.ts
@@ -24,6 +24,8 @@ import AuditHelpDeleteOutput from './audit/help/AuditHelpDeleteOutput.ts';
 import AuditHelpMutationsType from './audit/help/AuditHelpMutationsType.ts';
 import AuditHelpQueriesType from './audit/help/AuditHelpQueriesType.ts';
 import AuditHelpType from './audit/help/AuditHelpType.ts';
+import ApplicationConfigType from './commons/ApplicationConfigType.ts';
+import DataDogConfigType from './commons/DataDogConfigType.ts';
 import LinkType from './commons/LinkType.ts';
 import ModuleType from './commons/ModuleType.ts';
 import RepositoryType from './commons/RepositoryType.ts';
@@ -68,6 +70,8 @@ const VitalityTypes = gql(`
     scalar JSON
 
     # common schemas
+    ${DataDogConfigType}
+    ${ApplicationConfigType}
     ${LinkType}
     ${RepositoryType}
     ${KeywordType}

--- a/v6y-apps/bff/src/types/application/ApplicationCreateOrEditInput.ts
+++ b/v6y-apps/bff/src/types/application/ApplicationCreateOrEditInput.ts
@@ -26,6 +26,18 @@ const ApplicationCreateOrEditInput = `
       
       """ Additional Application production urls """
       additionalProductionLinks: [String]
+
+      """ DataDog API Key """
+      dataDogApiKey: String
+      
+      """ DataDog APP Key """
+      dataDogAppKey: String
+      
+      """ DataDog URL """
+      dataDogUrl: String
+      
+      """ DataDog Monitor ID """
+      dataDogMonitorId: String
        
       """ APP Contact Mail """
       contactMail: String!

--- a/v6y-apps/bff/src/types/application/ApplicationType.ts
+++ b/v6y-apps/bff/src/types/application/ApplicationType.ts
@@ -17,6 +17,9 @@ const ApplicationType = `
     
     """ First matched APP Web Repository Information """
     repo: RepositoryType
+
+    """ APP Configuration """
+    configuration: ApplicationConfigType
     
     """ Application links: prod, gitlab, github, aws """
     links: [LinkType]

--- a/v6y-apps/bff/src/types/commons/ApplicationConfigType.ts
+++ b/v6y-apps/bff/src/types/commons/ApplicationConfigType.ts
@@ -1,0 +1,7 @@
+const ApplicationConfigType = `
+    type ApplicationConfigType {
+        """ DataDog configuration """
+        dataDog: DataDogConfigType
+    }
+`;
+export default ApplicationConfigType;

--- a/v6y-apps/bff/src/types/commons/DataDogConfigType.ts
+++ b/v6y-apps/bff/src/types/commons/DataDogConfigType.ts
@@ -1,0 +1,18 @@
+const DataDogConfigType = `
+    """ DataDog configuration """
+    type DataDogConfigType {
+        """ DataDog API Key """
+        apiKey: String
+
+        """ DataDog Application Key """
+        appKey: String
+
+        """ DataDog url """
+        url: String
+
+        """ DataDog Monitor ID """
+        monitorId: String
+    }
+`;
+
+export default DataDogConfigType;

--- a/v6y-apps/front-bo/public/locales/en/common.json
+++ b/v6y-apps/front-bo/public/locales/en/common.json
@@ -162,6 +162,7 @@
       "app-git-repository-group": "Git Repository Information",
       "app-required-links-group": "Production Link(s)",
       "app-optional-link-group": "Other Link(s)",
+      "app-datadog-configuration-group": "Datadog Configuration (optional)",
       "app-name": {
         "label": "Application name",
         "placeholder": "Enter your application name",
@@ -218,8 +219,29 @@
         "label": "Application deployment platform link",
         "placeholder": "Enter your application deployment platform link",
         "error": ""
+      },
+      "app-data-dog-api-key": {
+        "label": "Application DataDog API Key",
+        "placeholder": "Enter your application DataDog API Key",
+        "error": ""
+      },
+      "app-data-dog-app-key": {
+        "label": "Application DataDog APP Key",
+        "placeholder": "Enter your application DataDog APP Key",
+        "error": ""
+      },
+      "app-data-dog-url": {
+        "label": "Application DataDog API URL",
+        "placeholder": "Enter your application DataDog API URL (should look like https://api.datadoghq.com/)",
+        "error": "The format of the DataDog URL is invalid! It should look like this: https://api.datadoghq.com/ and can change depending on your organization."
+      },
+      "app-data-dog-monitor-id": {
+        "label": "Application DataDog Monitor ID",
+        "placeholder": "Enter your application DataDog Monitor ID",
+        "error": ""
       }
     },
+    
     "titles": {
       "create": "Create Application",
       "edit": "Edit Application",

--- a/v6y-apps/front-bo/public/locales/fr/common.json
+++ b/v6y-apps/front-bo/public/locales/fr/common.json
@@ -162,6 +162,7 @@
       "app-git-repository-group": "Git Repository Information",
       "app-required-links-group": "Production Link(s)",
       "app-optional-link-group": "Other Link(s)",
+      "app-datadog-configuration-group": "Datadog Configuration (optional)",
       "app-name": {
         "label": "Application name",
         "placeholder": "Enter your application name",
@@ -218,8 +219,29 @@
         "label": "Application deployment platform link",
         "placeholder": "Enter your application deployment platform link",
         "error": ""
+      },
+      "app-data-dog-api-key": {
+        "label": "Application DataDog API Key",
+        "placeholder": "Enter your application DataDog API Key",
+        "error": ""
+      },
+      "app-data-dog-app-key": {
+        "label": "Application DataDog APP Key",
+        "placeholder": "Enter your application DataDog APP Key",
+        "error": ""
+      },
+      "app-data-dog-url": {
+        "label": "Application DataDog API URL",
+        "placeholder": "Enter your application DataDog API URL (should look like https://api.datadoghq.com/)",
+        "error": "The format of the DataDog URL is invalid! It should look like this: https://api.datadoghq.com/ and can change depending on your organization."
+      },
+      "app-data-dog-monitor-id": {
+        "label": "Application DataDog Monitor ID",
+        "placeholder": "Enter your application DataDog Monitor ID",
+        "error": ""
       }
     },
+    
     "titles": {
       "create": "Create Application",
       "edit": "Edit Application",

--- a/v6y-apps/front-bo/src/__tests__/VitalityFormConfig-test.ts
+++ b/v6y-apps/front-bo/src/__tests__/VitalityFormConfig-test.ts
@@ -6,6 +6,7 @@ import {
     applicationCreateEditItems,
     applicationCreateOrEditFormInAdapter,
     applicationCreateOrEditFormOutputAdapter,
+    applicationDataDogConfigurationFormItems,
     applicationGitRepositoryFormItems,
     applicationInfosFormItems,
     applicationOptionalLinksFormItems,
@@ -51,6 +52,15 @@ describe('VitalityFormConfig - Form Items', () => {
         expect(result[2].id).toBe('app-deployment-platform-link');
     });
 
+    it('should generate datadog configuration form items correctly', () => {
+        const result = applicationDataDogConfigurationFormItems(mockTranslate);
+        expect(result).toHaveLength(4);
+        expect(result[0].id).toBe('app-data-dog-api-key');
+        expect(result[1].id).toBe('app-data-dog-app-key');
+        expect(result[2].id).toBe('app-data-dog-url');
+        expect(result[3].id).toBe('app-data-dog-monitor-id');
+    });
+
     it('should correctly adapt application data for form input', () => {
         const application: ApplicationType = {
             _id: 1,
@@ -68,6 +78,14 @@ describe('VitalityFormConfig - Form Items', () => {
                 { label: 'Additional production url (1)', value: 'https://testapp2.com' },
                 { label: 'Additional production url (2)', value: 'https://testapp3.com' },
             ] as LinkType[],
+            configuration: {
+                dataDog: {
+                    apiKey: 'testApiKey',
+                    appKey: 'testAppKey',
+                    monitorId: 'testMonitorId',
+                    url: 'https://api.testdatadog.com',
+                },
+            },
         };
 
         const result = applicationCreateOrEditFormInAdapter(application);
@@ -83,6 +101,10 @@ describe('VitalityFormConfig - Form Items', () => {
             'app-production-link-1': 'https://testapp.com',
             'app-production-link-2': 'https://testapp2.com',
             'app-production-link-3': 'https://testapp3.com',
+            'app-data-dog-api-key': 'testApiKey',
+            'app-data-dog-app-key': 'testAppKey',
+            'app-data-dog-url': 'https://api.testdatadog.com',
+            'app-data-dog-monitor-id': 'testMonitorId',
         });
     });
 
@@ -99,6 +121,10 @@ describe('VitalityFormConfig - Form Items', () => {
             'app-production-link-1': 'https://testapp.com',
             'app-production-link-2': 'https://testapp2.com',
             'app-production-link-3': 'https://testapp3.com',
+            'app-data-dog-api-key': 'testApiKey',
+            'app-data-dog-app-key': 'testAppKey',
+            'app-data-dog-url': 'https://api.testdatadog.com',
+            'app-data-dog-monitor-id': 'testMonitorId',
         };
 
         const result = applicationCreateOrEditFormOutputAdapter(formData);
@@ -114,6 +140,10 @@ describe('VitalityFormConfig - Form Items', () => {
                 gitUrl: 'https://git.testrepo.com',
                 productionLink: 'https://testapp.com',
                 additionalProductionLinks: ['https://testapp2.com', 'https://testapp3.com'],
+                dataDogApiKey: 'testApiKey',
+                dataDogAppKey: 'testAppKey',
+                dataDogUrl: 'https://api.testdatadog.com',
+                dataDogMonitorId: 'testMonitorId',
             },
         });
     });
@@ -158,6 +188,10 @@ describe('VitalityFormConfig - Form Items', () => {
             'app-production-link-1': undefined,
             'app-production-link-2': undefined,
             'app-production-link-3': undefined,
+            'app-data-dog-api-key': undefined,
+            'app-data-dog-app-key': undefined,
+            'app-data-dog-url': undefined,
+            'app-data-dog-monitor-id': undefined,
         });
     });
 

--- a/v6y-apps/front-bo/src/commons/config/VitalityFormConfig.tsx
+++ b/v6y-apps/front-bo/src/commons/config/VitalityFormConfig.tsx
@@ -155,6 +155,42 @@ export const applicationOptionalLinksFormItems = (translate: TranslateType) => [
     },
 ];
 
+export const applicationDataDogConfigurationFormItems = (translate: TranslateType) => [
+    {
+        id: 'app-data-dog-api-key',
+        name: 'app-data-dog-api-key',
+        label: translate('v6y-applications.fields.app-data-dog-api-key.label'),
+        placeholder: translate('v6y-applications.fields.app-data-dog-api-key.placeholder'),
+        rules: [],
+    },
+    {
+        id: 'app-data-dog-app-key',
+        name: 'app-data-dog-app-key',
+        label: translate('v6y-applications.fields.app-data-dog-app-key.label'),
+        placeholder: translate('v6y-applications.fields.app-data-dog-app-key.placeholder'),
+        rules: [],
+    },
+    {
+        id: 'app-data-dog-url',
+        name: 'app-data-dog-url',
+        label: translate('v6y-applications.fields.app-data-dog-url.label'),
+        placeholder: translate('v6y-applications.fields.app-data-dog-url.placeholder'),
+        rules: [
+            {
+                type: 'url',
+                message: translate('v6y-applications.fields.app-data-dog-url.error'),
+            },
+        ],
+    },
+    {
+        id: 'app-data-dog-monitor-id',
+        name: 'app-data-dog-monitor-id',
+        label: translate('v6y-applications.fields.app-data-dog-monitor-id.label'),
+        placeholder: translate('v6y-applications.fields.app-data-dog-monitor-id.placeholder'),
+        rules: [],
+    },
+];
+
 export const applicationCreateEditItems = (translate: TranslateType) => {
     return [
         <VitalityFormFieldSet
@@ -176,6 +212,11 @@ export const applicationCreateEditItems = (translate: TranslateType) => {
             key={translate('v6y-applications.fields.app-optional-link-group')}
             groupTitle={translate('v6y-applications.fields.app-optional-link-group')}
             items={applicationOptionalLinksFormItems(translate)}
+        />,
+        <VitalityFormFieldSet
+            key={translate('v6y-applications.fields.app-datadog-configuration-group')}
+            groupTitle={translate('v6y-applications.fields.app-datadog-configuration-group')}
+            items={applicationDataDogConfigurationFormItems(translate)}
         />,
     ];
 };
@@ -207,6 +248,10 @@ export const applicationCreateOrEditFormInAdapter = (params: ApplicationType) =>
     'app-deployment-platform-link': params?.['links']?.find?.(
         (item) => item.label === 'Application deployment platform url',
     )?.value,
+    'app-data-dog-api-key': params?.['configuration']?.dataDog?.apiKey,
+    'app-data-dog-app-key': params?.['configuration']?.dataDog?.appKey,
+    'app-data-dog-url': params?.['configuration']?.dataDog?.url,
+    'app-data-dog-monitor-id': params?.['configuration']?.dataDog?.monitorId,
 });
 
 export const applicationCreateOrEditFormOutputAdapter = (data: unknown): Variables => {
@@ -229,6 +274,10 @@ export const applicationCreateOrEditFormOutputAdapter = (data: unknown): Variabl
             codeQualityPlatformLink: params?.['app-code-quality-platform-link'],
             ciPlatformLink: params?.['app-ci-cd-platform-link'],
             deploymentPlatformLink: params?.['app-deployment-platform-link'],
+            dataDogApiKey: params?.['app-data-dog-api-key'],
+            dataDogAppKey: params?.['app-data-dog-app-key'],
+            dataDogUrl: params?.['app-data-dog-url'],
+            dataDogMonitorId: params?.['app-data-dog-monitor-id'],
         },
     };
 };

--- a/v6y-apps/front-bo/src/features/v6y-applications/apis/getApplicationDetails.ts
+++ b/v6y-apps/front-bo/src/features/v6y-applications/apis/getApplicationDetails.ts
@@ -18,6 +18,14 @@ const GetApplicationDetails = gql`
                 webUrl
                 gitUrl
             }
+            configuration {
+                dataDog {
+                    apiKey
+                    appKey
+                    monitorId
+                    url
+                }
+            }
         }
     }
 `;

--- a/v6y-libs/core-logic/src/database/ApplicationProvider.ts
+++ b/v6y-libs/core-logic/src/database/ApplicationProvider.ts
@@ -87,6 +87,10 @@ const formatApplicationInput = (application: ApplicationInputType): ApplicationT
         ciPlatformLink,
         deploymentPlatformLink,
         additionalProductionLinks,
+        dataDogApiKey,
+        dataDogAppKey,
+        dataDogUrl,
+        dataDogMonitorId,
     } = application || {};
 
     return {
@@ -123,6 +127,14 @@ const formatApplicationInput = (application: ApplicationInputType): ApplicationT
                 description: '',
             },
         ]?.filter((item) => item?.value),
+        configuration: {
+            dataDog: {
+                apiKey: dataDogApiKey,
+                appKey: dataDogAppKey,
+                url: dataDogUrl,
+                monitorId: dataDogMonitorId,
+            },
+        },
     };
 };
 

--- a/v6y-libs/core-logic/src/database/ApplicationProvider.ts
+++ b/v6y-libs/core-logic/src/database/ApplicationProvider.ts
@@ -128,12 +128,16 @@ const formatApplicationInput = (application: ApplicationInputType): ApplicationT
             },
         ]?.filter((item) => item?.value),
         configuration: {
-            dataDog: {
-                apiKey: dataDogApiKey,
-                appKey: dataDogAppKey,
-                url: dataDogUrl,
-                monitorId: dataDogMonitorId,
-            },
+            ...(dataDogApiKey && dataDogAppKey && dataDogUrl && dataDogMonitorId
+                ? {
+                      dataDog: {
+                          apiKey: dataDogApiKey,
+                          appKey: dataDogAppKey,
+                          url: dataDogUrl,
+                          monitorId: dataDogMonitorId,
+                      },
+                  }
+                : {}),
         },
     };
 };

--- a/v6y-libs/core-logic/src/types/ApplicationConfigType.ts
+++ b/v6y-libs/core-logic/src/types/ApplicationConfigType.ts
@@ -1,6 +1,6 @@
 export interface DataDogConfigType {
-    apiKey: string;
-    appKey: string;
-    url: string;
-    monitorId: string;
+    apiKey?: string;
+    appKey?: string;
+    url?: string;
+    monitorId?: string;
 }

--- a/v6y-libs/core-logic/src/types/ApplicationConfigType.ts
+++ b/v6y-libs/core-logic/src/types/ApplicationConfigType.ts
@@ -1,6 +1,6 @@
 export interface DataDogConfigType {
-    apiKey?: string;
-    appKey?: string;
-    url?: string;
-    monitorId?: string;
+    apiKey: string;
+    appKey: string;
+    url: string;
+    monitorId: string;
 }


### PR DESCRIPTION
This pull request introduces changes to integrate DataDog configuration into the application. The changes span multiple files, including the addition of new fields, types, and logging for DataDog configuration.

### DataDog Configuration Integration:

* **Application Mutations**:
  - Added DataDog fields (`dataDogApiKey`, `dataDogAppKey`, `dataDogUrl`, `dataDogMonitorId`) to the `createOrEditApplication` function.
  - Included logging for the new DataDog fields.

* **GraphQL Types**:
  - Imported new types `ApplicationConfigType` and `DataDogConfigType` in `VitalityTypes.ts`.
  - Added these types to the `VitalityTypes` schema.
  - Defined DataDog fields in `ApplicationCreateOrEditInput.ts` and `ApplicationType.ts`. 
  - Created new type definitions for `ApplicationConfigType` and `DataDogConfigType`.

* **Lang**:
  - Added DataDog-related labels and placeholders to English and French files. 

* **Form Configuration**:
  - Updated form items and adapters to include DataDog configuration fields in `VitalityFormConfig.tsx`. 

* **Testing**:
  - Added tests for DataDog configuration form items in `VitalityFormConfig-test.ts`. 

* **API Changes**:
  - Updated `getApplicationDetails.ts` to fetch DataDog configuration details.
  - Modified `ApplicationProvider.ts` to handle new DataDog configuration fields.