### PR TITLE
[REFACTOR]: disable max-lines-per-function rule for test files

### DIFF
--- a/v6y-apps/bfb-devops-auditor/eslint.config.mjs
+++ b/v6y-apps/bfb-devops-auditor/eslint.config.mjs
@@ -21,7 +21,7 @@ export default [
     {
         files: ['src/**/__tests__/**/*-test.ts', 'src/**/__tests__/**/*-test.js', 'src/**/*.test.{js,ts,tsx}'],
         rules: {
-            'max-lines-per-function': 'off', // Disable this rule for test files with describe blocks
+            'max-lines-per-function': 'off',
         },
     },
     eslintPluginPrettierRecommended,

--- a/v6y-apps/bfb-devops-auditor/eslint.config.mjs
+++ b/v6y-apps/bfb-devops-auditor/eslint.config.mjs
@@ -17,6 +17,13 @@ export default [
             'max-statements': ['error', 50], // per function
         },
     },
+    // Special rules for test files
+    {
+        files: ['src/**/__tests__/**/*-test.ts', 'src/**/__tests__/**/*-test.js', 'src/**/*.test.{js,ts,tsx}'],
+        rules: {
+            'max-lines-per-function': 'off', // Disable this rule for test files with describe blocks
+        },
+    },
     eslintPluginPrettierRecommended,
     {
         languageOptions: {

--- a/v6y-apps/bfb-dynamic-auditor/eslint.config.mjs
+++ b/v6y-apps/bfb-dynamic-auditor/eslint.config.mjs
@@ -21,7 +21,7 @@ export default [
     {
         files: ['src/**/__tests__/**/*-test.ts', 'src/**/__tests__/**/*-test.js', 'src/**/*.test.{js,ts,tsx}'],
         rules: {
-            'max-lines-per-function': 'off', // Disable this rule for test files with describe blocks
+            'max-lines-per-function': 'off',
         },
     },
     eslintPluginPrettierRecommended,

--- a/v6y-apps/bfb-dynamic-auditor/eslint.config.mjs
+++ b/v6y-apps/bfb-dynamic-auditor/eslint.config.mjs
@@ -17,6 +17,13 @@ export default [
             'max-statements': ['error', 50], // per function
         },
     },
+    // Special rules for test files
+    {
+        files: ['src/**/__tests__/**/*-test.ts', 'src/**/__tests__/**/*-test.js', 'src/**/*.test.{js,ts,tsx}'],
+        rules: {
+            'max-lines-per-function': 'off', // Disable this rule for test files with describe blocks
+        },
+    },
     eslintPluginPrettierRecommended,
     {
         languageOptions: {

--- a/v6y-apps/bfb-main-analyzer/eslint.config.mjs
+++ b/v6y-apps/bfb-main-analyzer/eslint.config.mjs
@@ -21,7 +21,7 @@ export default [
     {
         files: ['src/**/__tests__/**/*-test.ts', 'src/**/__tests__/**/*-test.js', 'src/**/*.test.{js,ts,tsx}'],
         rules: {
-            'max-lines-per-function': 'off', // Disable this rule for test files with describe blocks
+            'max-lines-per-function': 'off',
         },
     },
     eslintPluginPrettierRecommended,

--- a/v6y-apps/bfb-main-analyzer/eslint.config.mjs
+++ b/v6y-apps/bfb-main-analyzer/eslint.config.mjs
@@ -17,6 +17,13 @@ export default [
             'max-statements': ['error', 50], // per function
         },
     },
+    // Special rules for test files
+    {
+        files: ['src/**/__tests__/**/*-test.ts', 'src/**/__tests__/**/*-test.js', 'src/**/*.test.{js,ts,tsx}'],
+        rules: {
+            'max-lines-per-function': 'off', // Disable this rule for test files with describe blocks
+        },
+    },
     eslintPluginPrettierRecommended,
     {
         languageOptions: {

--- a/v6y-apps/bfb-static-auditor/eslint.config.mjs
+++ b/v6y-apps/bfb-static-auditor/eslint.config.mjs
@@ -21,7 +21,7 @@ export default [
     {
         files: ['src/**/__tests__/**/*-test.ts', 'src/**/__tests__/**/*-test.js', 'src/**/*.test.{js,ts,tsx}'],
         rules: {
-            'max-lines-per-function': 'off', // Disable this rule for test files with describe blocks
+            'max-lines-per-function': 'off',
         },
     },
     eslintPluginPrettierRecommended,

--- a/v6y-apps/bfb-static-auditor/eslint.config.mjs
+++ b/v6y-apps/bfb-static-auditor/eslint.config.mjs
@@ -17,6 +17,13 @@ export default [
             'max-statements': ['error', 50], // per function
         },
     },
+    // Special rules for test files
+    {
+        files: ['src/**/__tests__/**/*-test.ts', 'src/**/__tests__/**/*-test.js', 'src/**/*.test.{js,ts,tsx}'],
+        rules: {
+            'max-lines-per-function': 'off', // Disable this rule for test files with describe blocks
+        },
+    },
     eslintPluginPrettierRecommended,
     {
         languageOptions: {

--- a/v6y-apps/bfb-static-auditor/src/__tests__/CodeCouplingUtils-test.ts
+++ b/v6y-apps/bfb-static-auditor/src/__tests__/CodeCouplingUtils-test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines-per-function */
 import { auditStatus } from '@v6y/core-logic';
 import Madge from 'madge';
 import { describe, expect, it, vi } from 'vitest';

--- a/v6y-apps/bfb-static-auditor/src/__tests__/CodeModularityUtils-test.ts
+++ b/v6y-apps/bfb-static-auditor/src/__tests__/CodeModularityUtils-test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines-per-function */
 import { AppLogger } from '@v6y/core-logic';
 import { describe, expect, it, vi } from 'vitest';
 

--- a/v6y-apps/bff/eslint.config.mjs
+++ b/v6y-apps/bff/eslint.config.mjs
@@ -21,7 +21,7 @@ export default [
     {
         files: ['src/**/__tests__/**/*-test.ts', 'src/**/__tests__/**/*-test.js', 'src/**/*.test.{js,ts,tsx}'],
         rules: {
-            'max-lines-per-function': 'off', // Disable this rule for test files with describe blocks
+            'max-lines-per-function': 'off',
         },
     },
     eslintPluginPrettierRecommended,

--- a/v6y-apps/bff/eslint.config.mjs
+++ b/v6y-apps/bff/eslint.config.mjs
@@ -17,6 +17,13 @@ export default [
             'max-statements': ['error', 50], // per function
         },
     },
+    // Special rules for test files
+    {
+        files: ['src/**/__tests__/**/*-test.ts', 'src/**/__tests__/**/*-test.js', 'src/**/*.test.{js,ts,tsx}'],
+        rules: {
+            'max-lines-per-function': 'off', // Disable this rule for test files with describe blocks
+        },
+    },
     eslintPluginPrettierRecommended,
     {
         languageOptions: {

--- a/v6y-apps/front-bo/eslint.config.mjs
+++ b/v6y-apps/front-bo/eslint.config.mjs
@@ -12,6 +12,13 @@ const eslintConfig = [
             '@typescript-eslint/no-require-imports': 'off',
         },
     }),
+    // Special rules for test files
+    {
+        files: ['**/__tests__/**/*-test.ts', '**/__tests__/**/*-test.js', '**/*.test.{js,ts,tsx}'],
+        rules: {
+            'max-lines-per-function': 'off', // Disable this rule for test files with describe blocks
+        },
+    },
 ];
 
 export default eslintConfig;

--- a/v6y-apps/front-bo/eslint.config.mjs
+++ b/v6y-apps/front-bo/eslint.config.mjs
@@ -16,7 +16,7 @@ const eslintConfig = [
     {
         files: ['**/__tests__/**/*-test.ts', '**/__tests__/**/*-test.js', '**/*.test.{js,ts,tsx}'],
         rules: {
-            'max-lines-per-function': 'off', // Disable this rule for test files with describe blocks
+            'max-lines-per-function': 'off',
         },
     },
 ];

--- a/v6y-apps/front/eslint.config.mjs
+++ b/v6y-apps/front/eslint.config.mjs
@@ -12,6 +12,13 @@ const eslintConfig = [
             '@typescript-eslint/no-require-imports': 'off',
         },
     }),
+    // Special rules for test files
+    {
+        files: ['**/__tests__/**/*-test.ts', '**/__tests__/**/*-test.js', '**/*.test.{js,ts,tsx}'],
+        rules: {
+            'max-lines-per-function': 'off', // Disable this rule for test files with describe blocks
+        },
+    },
 ];
 
 export default eslintConfig;

--- a/v6y-apps/front/eslint.config.mjs
+++ b/v6y-apps/front/eslint.config.mjs
@@ -16,7 +16,7 @@ const eslintConfig = [
     {
         files: ['**/__tests__/**/*-test.ts', '**/__tests__/**/*-test.js', '**/*.test.{js,ts,tsx}'],
         rules: {
-            'max-lines-per-function': 'off', // Disable this rule for test files with describe blocks
+            'max-lines-per-function': 'off',
         },
     },
 ];

--- a/v6y-libs/core-logic/eslint.config.mjs
+++ b/v6y-libs/core-logic/eslint.config.mjs
@@ -21,7 +21,7 @@ export default [
     {
         files: ['src/**/__tests__/**/*-test.ts', 'src/**/__tests__/**/*-test.js', 'src/**/*.test.{js,ts,tsx}'],
         rules: {
-            'max-lines-per-function': 'off', // Disable this rule for test files with describe blocks
+            'max-lines-per-function': 'off',
         },
     },
     eslintPluginPrettierRecommended,

--- a/v6y-libs/core-logic/eslint.config.mjs
+++ b/v6y-libs/core-logic/eslint.config.mjs
@@ -17,6 +17,13 @@ export default [
             'max-statements': ['error', 50], // per function
         },
     },
+    // Special rules for test files
+    {
+        files: ['src/**/__tests__/**/*-test.ts', 'src/**/__tests__/**/*-test.js', 'src/**/*.test.{js,ts,tsx}'],
+        rules: {
+            'max-lines-per-function': 'off', // Disable this rule for test files with describe blocks
+        },
+    },
     eslintPluginPrettierRecommended,
     {
         languageOptions: {

--- a/v6y-libs/ui-guide/eslint.config.js
+++ b/v6y-libs/ui-guide/eslint.config.js
@@ -27,7 +27,7 @@ export default tseslint.config(
     {
         files: ['**/__tests__/**/*-test.ts', '**/__tests__/**/*-test.js', '**/*.test.{js,ts,tsx}'],
         rules: {
-            'max-lines-per-function': 'off', // Disable this rule for test files with describe blocks
+            'max-lines-per-function': 'off',
         },
     },
     eslintConfigPrettier,

--- a/v6y-libs/ui-guide/eslint.config.js
+++ b/v6y-libs/ui-guide/eslint.config.js
@@ -23,5 +23,12 @@ export default tseslint.config(
             'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
         },
     },
+    // Special rules for test files
+    {
+        files: ['**/__tests__/**/*-test.ts', '**/__tests__/**/*-test.js', '**/*.test.{js,ts,tsx}'],
+        rules: {
+            'max-lines-per-function': 'off', // Disable this rule for test files with describe blocks
+        },
+    },
     eslintConfigPrettier,
 );

--- a/v6y-libs/ui-kit/eslint.config.js
+++ b/v6y-libs/ui-kit/eslint.config.js
@@ -24,5 +24,12 @@ export default tseslint.config(
             'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
         },
     },
+    // Special rules for test files
+    {
+        files: ['**/__tests__/**/*-test.ts', '**/__tests__/**/*-test.js', '**/*.test.{js,ts,tsx}'],
+        rules: {
+            'max-lines-per-function': 'off', // Disable this rule for test files with describe blocks
+        },
+    },
     eslintConfigPrettier,
 );

--- a/v6y-libs/ui-kit/eslint.config.js
+++ b/v6y-libs/ui-kit/eslint.config.js
@@ -28,7 +28,7 @@ export default tseslint.config(
     {
         files: ['**/__tests__/**/*-test.ts', '**/__tests__/**/*-test.js', '**/*.test.{js,ts,tsx}'],
         rules: {
-            'max-lines-per-function': 'off', // Disable this rule for test files with describe blocks
+            'max-lines-per-function': 'off',
         },
     },
     eslintConfigPrettier,


### PR DESCRIPTION
This pull request includes changes across multiple files to add special ESLint rules for test files, disabling the `max-lines-per-function` rule specifically for test files with describe blocks. Additionally, it removes individual ESLint disable comments from test files where this rule was previously disabled.

ESLint configuration updates:

* Added special rules for test files in `eslint.config.mjs` files across various projects, disabling the `max-lines-per-function` rule for test files with describe blocks.

Code cleanup:
* Removed `/* eslint-disable max-lines-per-function */` comments from test files in `v6y-apps/bfb-static-auditor`. 