### PR TITLE
New Frontend Static Auditor - Bundle Analyze

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -958,7 +958,7 @@ importers:
         specifier: '=1.10.0'
         version: 1.10.0
       package-manager-detector:
-        specifier: ^1.2.0
+        specifier: '=1.2.0'
         version: 1.2.0
       passport:
         specifier: '=0.7.0'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -957,6 +957,9 @@ importers:
       morgan:
         specifier: '=1.10.0'
         version: 1.10.0
+      package-manager-detector:
+        specifier: ^1.2.0
+        version: 1.2.0
       passport:
         specifier: '=0.7.0'
         version: 0.7.0
@@ -8149,6 +8152,9 @@ packages:
 
   package-manager-detector@0.1.2:
     resolution: {integrity: sha512-iePyefLTOm2gEzbaZKSW+eBMjg+UYsQvUKxmvGXAQ987K16efBg10MxIjZs08iyX+DY2/owKY9DIdu193kX33w==}
+
+  package-manager-detector@1.2.0:
+    resolution: {integrity: sha512-PutJepsOtsqVfUsxCzgTTpyXmiAgvKptIgY4th5eq5UXXFhj5PxfQ9hnGkypMeovpAvVshFRItoFHYO18TCOqA==}
 
   pandemonium@1.5.0:
     resolution: {integrity: sha512-9PU9fy93rJhZHLMjX+4M1RwZPEYl6g7DdWKGmGNhkgBZR5+tOBVExNZc00kzdEGMxbaAvWdQy9MqGAScGwYlcA==}
@@ -18665,6 +18671,8 @@ snapshots:
   package-json-from-dist@1.0.1: {}
 
   package-manager-detector@0.1.2: {}
+
+  package-manager-detector@1.2.0: {}
 
   pandemonium@1.5.0: {}
 

--- a/v6y-apps/bfb-static-auditor/src/__tests__/BundleAnalyzeUtils-test.ts
+++ b/v6y-apps/bfb-static-auditor/src/__tests__/BundleAnalyzeUtils-test.ts
@@ -1,0 +1,108 @@
+/* eslint-disable */
+import { AuditUtils, auditStatus } from '@v6y/core-logic';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import BundleAnalyzeUtils from '../auditors/bundle-analyzer/BundleAnalyzeUtils.ts';
+
+vi.mock('@v6y/core-logic', async () => {
+    const actualModule = await vi.importActual('@v6y/core-logic');
+
+    return {
+        ...actualModule,
+        default: actualModule,
+        AuditUtils: {
+            getFrontendDirectories: vi.fn(),
+            getPackageManager: vi.fn(),
+        },
+    };
+});
+
+
+describe('BundleAnalyzeUtils', () => {
+    const mockApplicationId = 1;
+    const mockWorkspaceFolder = '/fake/workspace';
+    const mockModulePath = '/fake/workspace/module1';
+
+    beforeEach(() => {
+        vi.resetAllMocks();
+    });
+
+    it('getScoreStatus returns correct status for thresholds', () => {
+        expect(BundleAnalyzeUtils.getScoreStatus(100 * 1024)).toBe('success');
+        expect(BundleAnalyzeUtils.getScoreStatus(300 * 1024)).toBe('info');
+        expect(BundleAnalyzeUtils.getScoreStatus(800 * 1024)).toBe('warning');
+        expect(BundleAnalyzeUtils.getScoreStatus(2 * 1024 * 1024)).toBe('error');
+    });
+
+    it('should return an empty array if applicationId or workspaceFolder is missing', async () => {
+        const result1 = await BundleAnalyzeUtils.startBundleAnalyzeReports({
+            applicationId: undefined,
+            workspaceFolder: mockWorkspaceFolder,
+        });
+        expect(result1).toEqual([]);
+        const result2 = await BundleAnalyzeUtils.startBundleAnalyzeReports({
+            applicationId: mockApplicationId,
+            workspaceFolder: undefined,
+        });
+        expect(result2).toEqual([]);
+    });
+
+    it('should return an empty array if no frontend modules are found', async () => {
+        (AuditUtils.getFrontendDirectories as any).mockReturnValue([]);
+        const result = await BundleAnalyzeUtils.startBundleAnalyzeReports({
+            applicationId: mockApplicationId,
+            workspaceFolder: mockWorkspaceFolder,
+        });
+        expect(result).toEqual([]);
+    });
+
+    it('should return an empty array if no package manager is found', async () => {
+        (AuditUtils.getPackageManager as any).mockReturnValue(null);
+        const result = await BundleAnalyzeUtils.startBundleAnalyzeReports({
+            applicationId: mockApplicationId,
+            workspaceFolder: mockWorkspaceFolder,
+        });
+        expect(result).toEqual([]);
+    });
+
+    it('should return an error formated report if analyzeResult is errored', () => {
+       const mockBundleAnalyse = {
+            applicationId: mockApplicationId,
+            workspaceFolder: mockWorkspaceFolder,
+            modulePath: '/fake/workspace/module1',
+            analyzeResult: {
+                status: 'error' as 'error' | 'success',
+                extraInfos: 'No bundler detected in the module.',
+            }
+        }
+        
+        const result = BundleAnalyzeUtils.formatBundleAnalyzeResult(mockBundleAnalyse);
+        expect(result).toMatchObject({ auditStatus: auditStatus.failure, extraInfos: 'No bundler detected in the module.' });
+    });
+ 
+    it('should return a success formated report if analyzeResult is success', () => {
+        const mockBundleReport = {
+            applicationId: mockApplicationId,
+            workspaceFolder: mockWorkspaceFolder,
+            modulePath: mockModulePath,
+            analyzeResult: {
+                status: 'success' as 'error' | 'success',
+                report:{
+                    gzipSize: 12345,
+                }
+            }
+        }
+        const result = BundleAnalyzeUtils.formatBundleAnalyzeResult(mockBundleReport);
+        expect(result).toMatchObject({ auditStatus: auditStatus.success, score: 12345 });
+        expect(result?.score).toEqual(12345);
+    });
+
+    it('should return null if analyzeResult is null', () => {
+            const result = BundleAnalyzeUtils.formatBundleAnalyzeResult({
+                applicationId: mockApplicationId,
+                workspaceFolder: mockWorkspaceFolder,
+                modulePath: mockModulePath,
+                analyzeResult: null,
+            });
+            expect(result).toBeNull();
+        });
+});

--- a/v6y-apps/bfb-static-auditor/src/auditors/bundle-analyzer/BundleAnalyzeAuditor.ts
+++ b/v6y-apps/bfb-static-auditor/src/auditors/bundle-analyzer/BundleAnalyzeAuditor.ts
@@ -1,4 +1,4 @@
-import { AppLogger } from '@v6y/core-logic';
+import { AppLogger, AuditProvider } from '@v6y/core-logic';
 
 import { AuditCommonsType } from '../types/AuditCommonsType.ts';
 import BundleAnalyzeUtils from './BundleAnalyzeUtils.ts';
@@ -27,6 +27,11 @@ const startAuditorAnalysis = async ({ applicationId, workspaceFolder }: AuditCom
         const auditReports = await formatBundleAnalyzeReports({ workspaceFolder, applicationId });
         AppLogger.info(
             `[BundleAnalyzeAuditor - startAuditorAnalysis] auditReports:  ${auditReports}`,
+        );
+
+        await AuditProvider.insertAuditList(auditReports);
+        AppLogger.info(
+            `[BundleAnalyzeAuditor - startAuditorAnalysis] audit reports inserted successfully`,
         );
     } catch (error) {
         AppLogger.error(

--- a/v6y-apps/bfb-static-auditor/src/auditors/bundle-analyzer/BundleAnalyzeAuditor.ts
+++ b/v6y-apps/bfb-static-auditor/src/auditors/bundle-analyzer/BundleAnalyzeAuditor.ts
@@ -25,9 +25,6 @@ const startAuditorAnalysis = async ({ applicationId, workspaceFolder }: AuditCom
         }
 
         const auditReports = await formatBundleAnalyzeReports({ workspaceFolder, applicationId });
-        AppLogger.info(
-            `[BundleAnalyzeAuditor - startAuditorAnalysis] auditReports:  ${auditReports}`,
-        );
 
         await AuditProvider.insertAuditList(auditReports);
         AppLogger.info(

--- a/v6y-apps/bfb-static-auditor/src/auditors/bundle-analyzer/BundleAnalyzeAuditor.ts
+++ b/v6y-apps/bfb-static-auditor/src/auditors/bundle-analyzer/BundleAnalyzeAuditor.ts
@@ -9,7 +9,7 @@ import BundleAnalyzeUtils from './BundleAnalyzeUtils.ts';
  * @param workspaceFolder
  */
 
-const { formatBundleAnalyzeReports } = BundleAnalyzeUtils;
+const { startBundleAnalyzeReports } = BundleAnalyzeUtils;
 
 const startAuditorAnalysis = async ({ applicationId, workspaceFolder }: AuditCommonsType) => {
     try {
@@ -24,7 +24,7 @@ const startAuditorAnalysis = async ({ applicationId, workspaceFolder }: AuditCom
             return false;
         }
 
-        const auditReports = await formatBundleAnalyzeReports({ workspaceFolder, applicationId });
+        const auditReports = await startBundleAnalyzeReports({ workspaceFolder, applicationId });
 
         await AuditProvider.insertAuditList(auditReports);
         AppLogger.info(

--- a/v6y-apps/bfb-static-auditor/src/auditors/bundle-analyzer/BundleAnalyzeUtils.ts
+++ b/v6y-apps/bfb-static-auditor/src/auditors/bundle-analyzer/BundleAnalyzeUtils.ts
@@ -1,5 +1,5 @@
-import { AppLogger, AuditType, AuditUtils } from '@v6y/core-logic';
-import { exec, execSync } from 'child_process';
+import { AppLogger, AuditType, AuditUtils, auditStatus, scoreStatus } from '@v6y/core-logic';
+import { execSync } from 'child_process';
 import fs from 'fs/promises';
 import path from 'path';
 
@@ -8,97 +8,7 @@ import { AuditCommonsType } from '../types/AuditCommonsType.ts';
 const { getFrontendDirectories, getPackageManager, getBundler } = AuditUtils;
 
 /**
- * Analyze the bundle using the bundler.
- * @param module
- * @param bundler
- */
-const runAnalyzeTool = async (module: string, bundler: string, packageManager: string) => {
-    // for now, we only support next.js.
-    if (bundler === 'next') {
-        // check if the module has @next/bundle-analyzer
-        let hasBundleAnalyzer = false;
-        try {
-            const pkg = JSON.parse(await fs.readFile(path.join(module, 'package.json'), 'utf-8'));
-            hasBundleAnalyzer = Boolean(
-                (pkg.dependencies && pkg.dependencies['@next/bundle-analyzer']) ||
-                    (pkg.devDependencies && pkg.devDependencies['@next/bundle-analyzer']),
-            );
-        } catch (e) {
-            AppLogger.warn(
-                `[BundleAnalyzeUtils - runAnalyzeTool] Impossible to read the package.json file: ${e}`,
-            );
-        }
-
-        if (!hasBundleAnalyzer) {
-            AppLogger.warn(
-                `[BundleAnalyzeUtils - runAnalyzeTool] No @next/bundle-analyzer found in the module.`,
-            );
-            return null;
-        }
-
-        const analyseCmd = `ANALYZE=true ${packageManager} build`;
-        return new Promise((resolve, reject) => {
-            exec(analyseCmd, { cwd: module }, async (error, stdout, stderr) => {
-                if (error) {
-                    AppLogger.error(
-                        `[BundleAnalyzeUtils - runAnalyzeTool] error: ${error.message}`,
-                    );
-                    reject(error);
-                    return;
-                }
-                if (stderr) {
-                    AppLogger.error(`[BundleAnalyzeUtils - runAnalyzeTool] stderr: ${stderr}`);
-                }
-                AppLogger.info(`[BundleAnalyzeUtils - runAnalyzeTool] stdout: ${stdout}`);
-                const lines = stdout.split('\n');
-                // we now need to parse the output to get the bundles sizes
-                console.log('lines', lines);
-            });
-        });
-    } else {
-        AppLogger.warn(
-            `[BundleAnalyzeUtils - runAnalyzeTool] bundler: ${bundler} is not supported.`,
-        );
-        return null;
-    }
-};
-
-/**
- * Analyze the bundle using the bundler.
- * @param modulePath
- * @param packageManager
- */
-const analyzeModule = async (
-    modulePath: string,
-    packageManager: string,
-): Promise<AuditType | null> => {
-    try {
-        const bundler = await getBundler(modulePath);
-        if (!bundler) {
-            AppLogger.warn(
-                `[BundleAnalyzeUtils - analyzeModule] bundler: No bundler found in the frontend module.`,
-            );
-            return null;
-        }
-
-        AppLogger.info(
-            `[BundleAnalyzeUtils - analyzeBundle] bundler: ${bundler} found in the frontend module.`,
-        );
-
-        const outputAnalyze = await runAnalyzeTool(modulePath, bundler, packageManager);
-        AppLogger.debug('outputAnalyze', outputAnalyze);
-        if (!outputAnalyze || typeof outputAnalyze !== 'object') return null;
-
-        // here we convert the outputAnalyze to AuditType
-        return {} as AuditType;
-    } catch (error) {
-        AppLogger.error(`[BundleAnalyzeUtils - analyzeBundle] error: ${error}`);
-        return null;
-    }
-};
-
-/**
- * Format bundle analyze reports.
+ * Format the bundle analyze reports.
  * @param applicationId
  * @param workspaceFolder
  */
@@ -108,57 +18,245 @@ const formatBundleAnalyzeReports = async ({
 }: AuditCommonsType): Promise<AuditType[]> => {
     try {
         AppLogger.info(
-            `[BundleAnalyzeUtils - formatBundleAnalyzeReports] applicationId:  ${applicationId}`,
+            `[BundleAnalyzeUtils - formatBundleAnalyzeReports] applicationId: ${applicationId}`,
         );
         AppLogger.info(
-            `[BundleAnalyzeUtils - formatBundleAnalyzeReports] workspaceFolder:  ${workspaceFolder}`,
+            `[BundleAnalyzeUtils - formatBundleAnalyzeReports] workspaceFolder: ${workspaceFolder}`,
         );
-
         if (!applicationId || !workspaceFolder) {
+            AppLogger.warn('[BundleAnalyzeUtils] applicationId or workspaceFolder missing.');
             return [];
         }
-
         const frontendModules = getFrontendDirectories(workspaceFolder, []);
-
         if (!frontendModules.length) {
-            AppLogger.warn(
-                `[BundleAnalyzeUtils - formatBundleAnalyzeReports] frontendModule: No frontend modules found in the workspace.`,
-            );
+            AppLogger.warn('[BundleAnalyzeUtils] No frontend module found.');
             return [];
+        } else {
+            AppLogger.info(
+                `[BundleAnalyzeUtils] ${frontendModules.length} frontend modules found.`,
+            );
         }
-
-        AppLogger.info(
-            `[BundleAnalyzeUtils - formatBundleAnalyzeReports] frontendModules: ${frontendModules.length} modules found.`,
-        );
 
         const packageManager = await getPackageManager(workspaceFolder);
         if (!packageManager) {
-            AppLogger.warn(
-                `[BundleAnalyzeUtils - formatBundleAnalyzeReports] packageManager: No package manager found in the frontend module.`,
-            );
+            AppLogger.warn('[BundleAnalyzeUtils] No package manager found.');
             return [];
         }
+        AppLogger.info(`[BundleAnalyzeUtils] packageManager: ${packageManager}`);
 
-        AppLogger.info(
-            `[BundleAnalyzeUtils - formatBundleAnalyzeReports] packageManager: ${packageManager} found in the frontend module.`,
-        );
-
-        execSync(`${packageManager} install`, { cwd: workspaceFolder });
-        AppLogger.info(
-            `[BundleAnalyzeUtils - formatBundleAnalyzeReports] '${packageManager} install' command executed in the frontend module.`,
-        );
+        await installDependencies(packageManager, workspaceFolder);
 
         const bundleReports: AuditType[] = [];
         for (const modulePath of frontendModules) {
-            const report = await analyzeModule(modulePath, packageManager);
-            if (report) {
-                bundleReports.push(report);
+            const analyseResult = await analyzeModule(modulePath, packageManager);
+
+            const module = {
+                appId: applicationId,
+                path: path.relative(workspaceFolder, modulePath),
+                name: path.basename(modulePath),
+            };
+            if (!analyseResult) {
+                AppLogger.warn(
+                    `[BundleAnalyzeUtils] L'analyse du module ${module.name} n'a pas abouti.`,
+                );
+            } else if (analyseResult?.status === 'error') {
+                bundleReports.push({
+                    appId: applicationId,
+                    type: 'bundle-analyze',
+                    category: 'bundle-max-size',
+                    auditStatus: auditStatus.failure,
+                    score: null,
+                    scoreStatus: null,
+                    scoreUnit: 'bytes',
+                    module: module,
+                    extraInfos: analyseResult?.extraInfos,
+                });
+            } else {
+                bundleReports.push({
+                    appId: applicationId,
+                    type: 'bundle-analyze',
+                    category: 'bundle-max-size',
+                    auditStatus: auditStatus.success,
+                    score: analyseResult?.report?.gzipSize,
+                    scoreStatus: analyseResult?.report
+                        ? getScoreStatus(analyseResult?.report?.gzipSize)
+                        : null,
+                    scoreUnit: 'bytes',
+                    module: module,
+                    extraInfos: analyseResult?.extraInfos,
+                });
             }
         }
         return bundleReports;
     } catch (error) {
-        AppLogger.error(`[BundleAnalyzeUtils - formatBundleAnalyzeReports] error:  ${error}`);
+        AppLogger.error(`[BundleAnalyzeUtils] Erreur globale: ${error}`);
         return [];
+    }
+};
+
+/**
+ * Installs the dependencies of the project using the specified package manager.
+ * @param packageManager - The package manager to use (e.g., npm, yarn).
+ * @param workspaceFolder - The path to the workspace folder.
+ */
+const installDependencies = async (packageManager: string, workspaceFolder: string) => {
+    try {
+        AppLogger.info(
+            `[BundleAnalyzeUtils] Installing dependencies with '${packageManager} install'...`,
+        );
+        execSync(`${packageManager} install`, { cwd: workspaceFolder });
+    } catch (error) {
+        AppLogger.error(`[BundleAnalyzeUtils] Error while installing dependencies: ${error}`);
+        throw error;
+    }
+};
+
+type AnalyzeResult = {
+    status: 'success' | 'error';
+    report?: { gzipSize: number };
+    extraInfos?: string;
+} | null;
+
+/**
+ * Analyzes the module using the specified package manager.
+ * @param modulePath - The path to the module to analyze.
+ * @param packageManager - The package manager to use (e.g., npm, yarn).
+ */
+async function analyzeModule(modulePath: string, packageManager: string): Promise<AnalyzeResult> {
+    try {
+        AppLogger.info(`[BundleAnalyzeUtils] Analyzing module: ${path.basename(modulePath)}`);
+
+        const bundler = await getBundler(modulePath);
+        if (!bundler) {
+            AppLogger.warn('[BundleAnalyzeUtils] No bundler detected.');
+            return { status: 'error', extraInfos: 'No bundler detected in the module.' };
+        }
+        AppLogger.info(`[BundleAnalyzeUtils] Bundler detected: ${bundler}`);
+
+        const supportedBundlers = ['next'];
+        if (!supportedBundlers.includes(bundler)) {
+            AppLogger.warn(`[BundleAnalyzeUtils] Unsupported bundler: ${bundler}`);
+            return null;
+        }
+
+        const outputAnalyze = await runAnalyzeTool(modulePath, bundler, packageManager);
+
+        if (!outputAnalyze) {
+            return {
+                status: 'error',
+                extraInfos:
+                    'Cannot analyze the bundle. Did you set up the bundle analyzer in your project?',
+            };
+        }
+        return { status: 'success', report: outputAnalyze };
+    } catch (error) {
+        AppLogger.error(`[BundleAnalyzeUtils] Error in analyzeModule: ${error}`);
+        return { status: 'error', extraInfos: 'Unexpected error occurred during analysis.' };
+    }
+}
+
+interface AnalyzeToolResult {
+    gzipSize: number;
+}
+/**
+ * Runs the analysis tool for the specified module and bundler.
+ * @param module - The path to the module to analyze.
+ * @param bundler - The bundler to use (e.g., next).
+ * @param packageManager - The package manager to use (e.g., pnpm, yarn).
+ */
+const runAnalyzeTool = async (
+    module: string,
+    bundler: string,
+    packageManager: string,
+): Promise<AnalyzeToolResult | null> => {
+    if (!(await isBundlerAnalyzerSetup(module, bundler))) return null;
+
+    AppLogger.info(
+        `[BundleAnalyzeUtils - runAnalyzeToolRefactored] Bundler analyzer correctly set up.`,
+    );
+    AppLogger.info(
+        `[BundleAnalyzeUtils - runAnalyzeToolRefactored] Running the analyze command...`,
+    );
+    if (bundler === 'next') {
+        const analyzeCmd = `ANALYZE=true ${packageManager} build`;
+        try {
+            execSync(analyzeCmd, { cwd: module, stdio: 'inherit' });
+        } catch (error) {
+            AppLogger.error(`[BundleAnalyzeUtils] Build error: ${error}`);
+            return null;
+        }
+        const analyzeFilePath = path.join(module, '.next', 'analyze', 'client.html');
+        const raw = await fs.readFile(analyzeFilePath, 'utf-8');
+        const bundles = JSON.parse(raw);
+        const sorted = [...bundles].sort((a, b) => b.gzipSize - a.gzipSize);
+        return sorted[0] || null;
+    }
+    return null;
+};
+
+/**
+ * Checks if the bundler analyzer is set up correctly in the module.
+ * @param module - The path to the module to check.
+ * @param bundler - The bundler to check (e.g., next).
+ */
+const isBundlerAnalyzerSetup = async (module: string, bundler: string): Promise<boolean> => {
+    try {
+        if (bundler === 'next') {
+            const pkg = JSON.parse(await fs.readFile(path.join(module, 'package.json'), 'utf-8'));
+            const hasBundleAnalyzerDependency =
+                (pkg.dependencies && pkg.dependencies['@next/bundle-analyzer']) ||
+                (pkg.devDependencies && pkg.devDependencies['@next/bundle-analyzer']);
+
+            if (!hasBundleAnalyzerDependency) {
+                AppLogger.warn(`[BundleAnalyzeUtils] No @next/bundle-analyzer found in ${module}`);
+                return false;
+            }
+
+            const files = await fs.readdir(module);
+            const configFile = files.find((f) => /^next\.config\.(js|mjs|cjs|ts)$/.test(f));
+            if (!configFile) {
+                AppLogger.warn(`[BundleAnalyzeUtils] No next.config file found in ${module}`);
+                return false;
+            }
+            const nextConfigPath = path.join(module, configFile);
+            try {
+                const configContent = await fs.readFile(nextConfigPath, 'utf-8');
+                const hasAnalyzerModeJson = /analyzerMode\s*:\s*['"]json['"]/.test(configContent);
+                const hasEnabledAnalyzeEnv =
+                    /enabled\s*:\s*process\.env\.ANALYZE\s*===\s*['"]true['"]/.test(configContent);
+                return hasAnalyzerModeJson && hasEnabledAnalyzeEnv;
+            } catch (e) {
+                AppLogger.warn(`[BundleAnalyzeUtils] Unable to read next.config.js: ${e}`);
+                return false;
+            }
+        }
+        return false;
+    } catch (e) {
+        AppLogger.warn(`[BundleAnalyzeUtils] Unable to read package.json: ${e}`);
+        return false;
+    }
+};
+
+/**
+ * Returns the score status based on the provided gzip size in bytes.
+ *
+ * The thresholds are based on web statistics as of April 1st, 2024:
+ * - Success: gzip size is less than 200 KB (5% of websites are below this size)
+ * - Info: gzip size is less than 600 KB (10% of websites are below this size)
+ * - Warning: gzip size is less than 1 MB (20% of websites are below this size)
+ * - Error: gzip size is 1 MB or more (30% of websites are below 1.5 MB)
+ *
+ * @param gzipSize - The size of the bundle in bytes after gzip compression.
+ */
+const getScoreStatus = (gzipSize: number): string => {
+    if (gzipSize < 200 * 1024) {
+        return scoreStatus.success;
+    } else if (gzipSize < 600 * 1024) {
+        return scoreStatus.info;
+    } else if (gzipSize < 1 * 1024 * 1024) {
+        return scoreStatus.warning;
+    } else {
+        return scoreStatus.error;
     }
 };
 
@@ -167,3 +265,4 @@ const BundleAnalyzeUtils = {
 };
 
 export default BundleAnalyzeUtils;
+export { installDependencies, analyzeModule };

--- a/v6y-apps/bfb-static-auditor/src/auditors/bundle-analyzer/BundleAnalyzeUtils.ts
+++ b/v6y-apps/bfb-static-auditor/src/auditors/bundle-analyzer/BundleAnalyzeUtils.ts
@@ -1,26 +1,99 @@
-import { AppLogger, AuditUtils } from '@v6y/core-logic';
+import { AppLogger, AuditType, AuditUtils } from '@v6y/core-logic';
+import { exec, execSync } from 'child_process';
+import fs from 'fs/promises';
+import path from 'path';
 
 import { AuditCommonsType } from '../types/AuditCommonsType.ts';
 
-const { getFrontendDirectories } = AuditUtils;
+const { getFrontendDirectories, getPackageManager, getBundler } = AuditUtils;
 
 /**
- * Get the frontend bundler used in the project.
- * @param workspaceFolder
- * @param frontendModule
+ * Analyze the bundle using the bundler.
+ * @param module
+ * @param bundler
  */
+const runAnalyzeTool = async (module: string, bundler: string, packageManager: string) => {
+    // for now, we only support next.js.
+    if (bundler === 'next') {
+        // check if the module has @next/bundle-analyzer
+        let hasBundleAnalyzer = false;
+        try {
+            const pkg = JSON.parse(await fs.readFile(path.join(module, 'package.json'), 'utf-8'));
+            hasBundleAnalyzer = Boolean(
+                (pkg.dependencies && pkg.dependencies['@next/bundle-analyzer']) ||
+                    (pkg.devDependencies && pkg.devDependencies['@next/bundle-analyzer']),
+            );
+        } catch (e) {
+            AppLogger.warn(
+                `[BundleAnalyzeUtils - runAnalyzeTool] Impossible to read the package.json file: ${e}`,
+            );
+        }
 
-const analyzeBundle = async (workspaceFolder: string) => {
-    const frontendModules = getFrontendDirectories(workspaceFolder, []);
-    if (!frontendModules.length) {
-        AppLogger.warn(
-            `[BundleAnalyzeUtils - analyzeBundle] frontendModule: No frontend modules found in the workspace.`,
-        );
+        if (!hasBundleAnalyzer) {
+            AppLogger.warn(
+                `[BundleAnalyzeUtils - runAnalyzeTool] No @next/bundle-analyzer found in the module.`,
+            );
+            return null;
+        }
+
+        const analyseCmd = `ANALYZE=true ${packageManager} build`;
+        return new Promise((resolve, reject) => {
+            exec(analyseCmd, { cwd: module }, async (error, stdout, stderr) => {
+                if (error) {
+                    AppLogger.error(
+                        `[BundleAnalyzeUtils - runAnalyzeTool] error: ${error.message}`,
+                    );
+                    reject(error);
+                    return;
+                }
+                if (stderr) {
+                    AppLogger.error(`[BundleAnalyzeUtils - runAnalyzeTool] stderr: ${stderr}`);
+                }
+                AppLogger.info(`[BundleAnalyzeUtils - runAnalyzeTool] stdout: ${stdout}`);
+                const lines = stdout.split('\n');
+                // we now need to parse the output to get the bundles sizes
+                console.log('lines', lines);
+            });
+        });
     } else {
-        AppLogger.info(
-            `[BundleAnalyzeUtils - analyzeBundle] frontendModule files:`,
-            frontendModules?.length,
+        AppLogger.warn(
+            `[BundleAnalyzeUtils - runAnalyzeTool] bundler: ${bundler} is not supported.`,
         );
+        return null;
+    }
+};
+
+/**
+ * Analyze the bundle using the bundler.
+ * @param modulePath
+ * @param packageManager
+ */
+const analyzeModule = async (
+    modulePath: string,
+    packageManager: string,
+): Promise<AuditType | null> => {
+    try {
+        const bundler = await getBundler(modulePath);
+        if (!bundler) {
+            AppLogger.warn(
+                `[BundleAnalyzeUtils - analyzeModule] bundler: No bundler found in the frontend module.`,
+            );
+            return null;
+        }
+
+        AppLogger.info(
+            `[BundleAnalyzeUtils - analyzeBundle] bundler: ${bundler} found in the frontend module.`,
+        );
+
+        const outputAnalyze = await runAnalyzeTool(modulePath, bundler, packageManager);
+        AppLogger.debug('outputAnalyze', outputAnalyze);
+        if (!outputAnalyze || typeof outputAnalyze !== 'object') return null;
+
+        // here we convert the outputAnalyze to AuditType
+        return {} as AuditType;
+    } catch (error) {
+        AppLogger.error(`[BundleAnalyzeUtils - analyzeBundle] error: ${error}`);
+        return null;
     }
 };
 
@@ -29,8 +102,10 @@ const analyzeBundle = async (workspaceFolder: string) => {
  * @param applicationId
  * @param workspaceFolder
  */
-
-const formatBundleAnalyzeReports = async ({ applicationId, workspaceFolder }: AuditCommonsType) => {
+const formatBundleAnalyzeReports = async ({
+    applicationId,
+    workspaceFolder,
+}: AuditCommonsType): Promise<AuditType[]> => {
     try {
         AppLogger.info(
             `[BundleAnalyzeUtils - formatBundleAnalyzeReports] applicationId:  ${applicationId}`,
@@ -43,9 +118,44 @@ const formatBundleAnalyzeReports = async ({ applicationId, workspaceFolder }: Au
             return [];
         }
 
-        const analyzeBundleReports = await analyzeBundle(workspaceFolder);
+        const frontendModules = getFrontendDirectories(workspaceFolder, []);
 
-        return analyzeBundleReports;
+        if (!frontendModules.length) {
+            AppLogger.warn(
+                `[BundleAnalyzeUtils - formatBundleAnalyzeReports] frontendModule: No frontend modules found in the workspace.`,
+            );
+            return [];
+        }
+
+        AppLogger.info(
+            `[BundleAnalyzeUtils - formatBundleAnalyzeReports] frontendModules: ${frontendModules.length} modules found.`,
+        );
+
+        const packageManager = await getPackageManager(workspaceFolder);
+        if (!packageManager) {
+            AppLogger.warn(
+                `[BundleAnalyzeUtils - formatBundleAnalyzeReports] packageManager: No package manager found in the frontend module.`,
+            );
+            return [];
+        }
+
+        AppLogger.info(
+            `[BundleAnalyzeUtils - formatBundleAnalyzeReports] packageManager: ${packageManager} found in the frontend module.`,
+        );
+
+        execSync(`${packageManager} install`, { cwd: workspaceFolder });
+        AppLogger.info(
+            `[BundleAnalyzeUtils - formatBundleAnalyzeReports] '${packageManager} install' command executed in the frontend module.`,
+        );
+
+        const bundleReports: AuditType[] = [];
+        for (const modulePath of frontendModules) {
+            const report = await analyzeModule(modulePath, packageManager);
+            if (report) {
+                bundleReports.push(report);
+            }
+        }
+        return bundleReports;
     } catch (error) {
         AppLogger.error(`[BundleAnalyzeUtils - formatBundleAnalyzeReports] error:  ${error}`);
         return [];

--- a/v6y-apps/bfb-static-auditor/src/auditors/bundle-analyzer/BundleAnalyzeUtils.ts
+++ b/v6y-apps/bfb-static-auditor/src/auditors/bundle-analyzer/BundleAnalyzeUtils.ts
@@ -91,7 +91,7 @@ const formatBundleAnalyzeResult = ({
         path: path.relative(workspaceFolder, modulePath),
     };
     if (!analyzeResult) {
-        AppLogger.warn(`[BundleAnalyzeUtils] L'analyze du module ${module.path} n'a pas abouti.`);
+        AppLogger.warn(`[BundleAnalyzeUtils] No analyze result for module: ${modulePath}`);
         return null;
     } else if (analyzeResult?.status === 'error') {
         return {

--- a/v6y-apps/bfb-static-auditor/src/auditors/bundle-analyzer/BundleAnalyzeUtils.ts
+++ b/v6y-apps/bfb-static-auditor/src/auditors/bundle-analyzer/BundleAnalyzeUtils.ts
@@ -66,7 +66,7 @@ const startBundleAnalyzeReports = async ({
         }
         return bundleReports;
     } catch (error) {
-        AppLogger.error(`[BundleAnalyzeUtils] Erreur globale: ${error}`);
+        AppLogger.error(`[BundleAnalyzeUtils] Error in startBundleAnalyzeReports: ${error}`);
         return [];
     }
 };
@@ -213,6 +213,8 @@ const runAnalyzeTool = async (
             AppLogger.error(`[BundleAnalyzeUtils] Build error: ${error}`);
             return null;
         }
+        // the analyze lib generate a file named client.html, even though it is a json file
+        // we may update that in the future if the library is updated
         const analyzeFilePath = path.join(module, '.next', 'analyze', 'client.html');
         const raw = await fs.readFile(analyzeFilePath, 'utf-8');
         const bundles = JSON.parse(raw);

--- a/v6y-apps/front-bo/next.config.mjs
+++ b/v6y-apps/front-bo/next.config.mjs
@@ -1,6 +1,7 @@
 import BundleAnalyzer from '@next/bundle-analyzer';
 
 const withBundleAnalyzer = BundleAnalyzer({
+    analyzerMode: 'json',
     enabled: process.env.ANALYZE === 'true',
 });
 

--- a/v6y-apps/front/next.config.mjs
+++ b/v6y-apps/front/next.config.mjs
@@ -1,6 +1,7 @@
 import BundleAnalyzer from '@next/bundle-analyzer';
 
 const withBundleAnalyzer = BundleAnalyzer({
+    analyzerMode: 'json',
     enabled: process.env.ANALYZE === 'true',
 });
 

--- a/v6y-libs/core-logic/package.json
+++ b/v6y-libs/core-logic/package.json
@@ -70,6 +70,7 @@
     "jsonwebtoken": "=9.0.2",
     "lodash": "=4.17.21",
     "morgan": "=1.10.0",
+    "package-manager-detector": "^1.2.0",
     "passport": "=0.7.0",
     "passport-jwt": "=4.0.1",
     "pg": "=8.13.1",

--- a/v6y-libs/core-logic/package.json
+++ b/v6y-libs/core-logic/package.json
@@ -70,7 +70,7 @@
     "jsonwebtoken": "=9.0.2",
     "lodash": "=4.17.21",
     "morgan": "=1.10.0",
-    "package-manager-detector": "^1.2.0",
+    "package-manager-detector": "=1.2.0",
     "passport": "=0.7.0",
     "passport-jwt": "=4.0.1",
     "pg": "=8.13.1",

--- a/v6y-libs/core-logic/src/core/AuditUtils.ts
+++ b/v6y-libs/core-logic/src/core/AuditUtils.ts
@@ -453,12 +453,12 @@ const isFrontend = (module: string): boolean => {
  */
 const getFrontendDirectories = (directory: string, frontendModules: string[]): string[] => {
     try {
+        const exceptions = ['node_modules', 'dist', 'build', 'out', 'target', '.next', 'outDir'];
         const files = fs.readdirSync(directory);
-        //AppLogger.info(`[AuditUtils - getFrontendDirectories] files: ${files?.length}`);
         frontendModules = frontendModules || [];
         files.forEach(function (module) {
-            if (module === 'node_modules') {
-                return; // Skip node_modules
+            if (exceptions.includes(module)) {
+                return;
             }
             const modulePath = path.join(directory, module);
             if (fs.statSync(modulePath).isDirectory()) {
@@ -474,7 +474,6 @@ const getFrontendDirectories = (directory: string, frontendModules: string[]): s
                 }
             }
         });
-        //AppLogger.info(`[AuditUtils - getFrontendDirectories] frontendFiles: ${frontendModules}`);
 
         return frontendModules;
     } catch (error) {


### PR DESCRIPTION
This pull request complete the bundle auditor by adding many steps in `BundleAnalyzeAuditor.ts`and `BundleAnalyzeUtils.ts`(install, build, analyse, formating, etc.) and tests on `BundleAnalyzeUtils-test.ts`

### Bundle Analysis Enhancements:
* Added the `startBundleAnalyzeReports` method to `BundleAnalyzeUtils`, replacing the older `formatBundleAnalyzeReports`, to streamline the bundle analysis process and integrate dependency installation, module analysis, and report formatting. 
* Introduced new helper methods in `BundleAnalyzeUtils`, such as `installDependencies`, `analyzeModule`, and `runAnalyzeTool`, to support detailed analysis of frontend modules using bundlers like Next.js.
* Added a new method `getScoreStatus` to categorize bundle sizes into success, info, warning, or error thresholds based on gzip size.

### Testing Improvements:
* Added comprehensive unit tests for `BundleAnalyzeUtils` in `BundleAnalyzeUtils-test.ts` to validate the behavior of methods like `startBundleAnalyzeReports`, `formatBundleAnalyzeResult`, and error handling scenarios.

### Configuration Updates:
* Updated `next.config.mjs` files for frontend applications to include `analyzerMode: 'json'` in the Next.js bundle analyzer configuration, enabling JSON-based bundle analysis. 

### Core Logic Enhancements:
* Enhanced `AuditUtils.getFrontendDirectories` to exclude common non-frontend directories (e.g., `node_modules`, `dist`, `.next`) from analysis.
* Integrated `package-manager-detector` in `AuditUtils` to detect the package manager used in a workspace.